### PR TITLE
WIP: Switch to `react-table`

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@miblanchard/react-native-slider": "^2.1.0",
         "@react-navigation/drawer": "^6.4.1",
         "@react-navigation/native": "^6.0.10",
+        "@tanstack/react-table": "^8.0.0-alpha.74",
         "react": "17.0.2",
         "react-data-grid": "^7.0.0-beta.12",
         "react-dom": "17.0.2",
@@ -3173,6 +3174,37 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.0.0-alpha.74",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.0.0-alpha.74.tgz",
+      "integrity": "sha512-FpBtVlhTJwghfGsoqK6hjDfhdWUNif35PFuyXRO33DmSE9vhw5Bt/qTu2yOdZSYZbdKJThX9Q9O5FBN7B1jJGQ==",
+      "dependencies": {
+        "@tanstack/table-core": "8.0.0-alpha.74"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.0.0-alpha.74",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.0.0-alpha.74.tgz",
+      "integrity": "sha512-ebEqgeOY6tlbpAYPmirJbhtyLYY/lt7nk4NgISviIZizc9PerBDdsrpAr1eDdtHysJBfIVBdOO6iNy7ai2Dg+g==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -19895,6 +19927,19 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@tanstack/react-table": {
+      "version": "8.0.0-alpha.74",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.0.0-alpha.74.tgz",
+      "integrity": "sha512-FpBtVlhTJwghfGsoqK6hjDfhdWUNif35PFuyXRO33DmSE9vhw5Bt/qTu2yOdZSYZbdKJThX9Q9O5FBN7B1jJGQ==",
+      "requires": {
+        "@tanstack/table-core": "8.0.0-alpha.74"
+      }
+    },
+    "@tanstack/table-core": {
+      "version": "8.0.0-alpha.74",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.0.0-alpha.74.tgz",
+      "integrity": "sha512-ebEqgeOY6tlbpAYPmirJbhtyLYY/lt7nk4NgISviIZizc9PerBDdsrpAr1eDdtHysJBfIVBdOO6iNy7ai2Dg+g=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@miblanchard/react-native-slider": "^2.1.0",
     "@react-navigation/drawer": "^6.4.1",
     "@react-navigation/native": "^6.0.10",
+    "@tanstack/react-table": "^8.0.0-alpha.74",
     "react": "17.0.2",
     "react-data-grid": "^7.0.0-beta.12",
     "react-dom": "17.0.2",

--- a/frontend/src/components/data/TrackTable/TrackTable.component.tsx
+++ b/frontend/src/components/data/TrackTable/TrackTable.component.tsx
@@ -23,7 +23,7 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
       onDoubleClickRow={item => {
         const track = item?._track;
         if (onPlay && track) {
-          onPlay(track);
+          onPlay({ track });
         }
       }}
     />

--- a/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
+++ b/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
@@ -44,18 +44,17 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
   });
 
   return (
-    <div style={styles.wrapper}>
-      <table style={styles.table}>
-        <thead style={styles.head}>
+    <div className="tt-wrapper">
+      <table className="tt-table">
+        <thead className="tt-head">
           {instance.getHeaderGroups().map(group => (
             <tr key={group.id}>
               {group.headers.map(header => (
                 <th
                   key={header.id}
                   colSpan={header.colSpan}
+                  className="tt-cell tt-head-cell"
                   style={{
-                    ...styles.headCell,
-                    ...styles.cell,
                     width: header.getSize(),
                   }}>
                   {header.isPlaceholder ? null : header.renderHeader()}
@@ -68,7 +67,7 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
           {instance.getRowModel().rows.map(row => (
             <tr key={row.id}>
               {row.getVisibleCells().map(cell => (
-                <td key={cell.id} style={styles.cell}>
+                <td key={cell.id} className="tt-cell">
                   {cell.renderCell()}
                 </td>
               ))}
@@ -76,6 +75,7 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
           ))}
         </tbody>
       </table>
+      <style>{styles}</style>
     </div>
   );
 });

--- a/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
+++ b/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
@@ -2,6 +2,7 @@ import { TrackTableProps } from '@bassment/components/data/TrackTable/TrackTable
 import { useTrackTableStyles } from '@bassment/components/data/TrackTable/TrackTable.style.web';
 import { ThemedIcon } from '@bassment/components/display/ThemedIcon';
 import { AnnotatedTrack } from '@bassment/models/Track';
+import { fromDrops } from '@bassment/utils/dropConversions.web';
 import {
   createTable,
   getCoreRowModel,
@@ -109,7 +110,6 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
                   ? ['tt-selected']
                   : ['tt-unselected']),
               ].join(' ')}
-              // TODO: Support dragging multiple elements
               draggable
               onClick={e => {
                 const id = row.original!.id!;
@@ -119,6 +119,18 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
                 } else {
                   setSelectedIds(new Set([id]));
                 }
+              }}
+              onDragStart={e => {
+                // TODO: Support dragging multiple elements, e.g. by dragging all selected ids instead?
+                fromDrops(
+                  [
+                    {
+                      kind: 'tracks',
+                      tracks: row.original ? [row.original] : [],
+                    },
+                  ],
+                  e.dataTransfer,
+                );
               }}
               onDoubleClick={() => {
                 if (onPlay) {

--- a/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
+++ b/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
@@ -75,7 +75,17 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
                   ? ['tt-selected']
                   : ['tt-unselected']),
               ].join(' ')}
-              onClick={() => setSelectedIds(new Set([row.original!.id!]))}
+              // TODO: Support dragging multiple elements
+              draggable
+              onClick={e => {
+                const id = row.original!.id!;
+                if (e.shiftKey) {
+                  // TODO: Select the range instead of just adding the id
+                  setSelectedIds(new Set([...selectedIds, id]));
+                } else {
+                  setSelectedIds(new Set([id]));
+                }
+              }}
               onDoubleClick={() => {
                 if (onPlay) {
                   onPlay(row.original!);

--- a/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
+++ b/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
@@ -13,7 +13,9 @@ const table = createTable().setRowType<AnnotatedTrack>();
 
 export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
   const styles = useTrackTableStyles();
-  const [selectedId, setSelectedId] = useState<number | undefined>(undefined);
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<number>>(
+    () => new Set(),
+  );
 
   const columns = useMemo(
     () => [
@@ -65,7 +67,20 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
         </thead>
         <tbody>
           {instance.getRowModel().rows.map(row => (
-            <tr key={row.id} className="tt-row">
+            <tr
+              key={row.id}
+              className={[
+                'tt-row',
+                ...(selectedIds.has(row.original!.id!)
+                  ? ['tt-selected']
+                  : ['tt-unselected']),
+              ].join(' ')}
+              onClick={() => setSelectedIds(new Set([row.original!.id!]))}
+              onDoubleClick={() => {
+                if (onPlay) {
+                  onPlay(row.original!);
+                }
+              }}>
               {row.getVisibleCells().map(cell => (
                 <td key={cell.id} className="tt-cell">
                   {cell.renderCell()}

--- a/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
+++ b/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
@@ -65,7 +65,7 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
         </thead>
         <tbody>
           {instance.getRowModel().rows.map(row => (
-            <tr key={row.id}>
+            <tr key={row.id} className="tt-row">
               {row.getVisibleCells().map(cell => (
                 <td key={cell.id} className="tt-cell">
                   {cell.renderCell()}

--- a/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
+++ b/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
@@ -101,7 +101,7 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
           ))}
         </thead>
         <tbody>
-          {instance.getRowModel().rows.map(row => (
+          {instance.getRowModel().rows.map((row, index) => (
             <tr
               key={row.id}
               className={[
@@ -133,8 +133,14 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
                 );
               }}
               onDoubleClick={() => {
-                if (onPlay) {
-                  onPlay(row.original!);
+                if (onPlay && row.original) {
+                  onPlay({
+                    track: row.original,
+                    base: instance
+                      .getRowModel()
+                      .rows.flatMap(r => (r.original ? [r.original] : []))
+                      .slice(index + 1),
+                  });
                 }
               }}>
               {row.getVisibleCells().map(cell => (

--- a/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
+++ b/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
@@ -7,16 +7,18 @@ import {
   useTableInstance,
 } from '@tanstack/react-table';
 import { AnnotatedTrack } from '@bassment/models/Track';
+import { useTrackTableStyles } from '@bassment/components/data/TrackTable/TrackTable.style.web';
 
 const table = createTable().setRowType<AnnotatedTrack>();
 
 export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
+  const styles = useTrackTableStyles();
   const [selectedId, setSelectedId] = useState<number | undefined>(undefined);
 
   const columns = useMemo(
     () => [
       table.createDataColumn('artists', {
-        header: () => 'Artists',
+        header: () => <div style={{ width: '50%' }}>Artists</div>,
       }),
       table.createDataColumn('title', {
         header: () => 'Title',
@@ -33,27 +35,31 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
   });
 
   return (
-    <table>
-      <thead>
-        {instance.getHeaderGroups().map(group => (
-          <tr key={group.id}>
-            {group.headers.map(header => (
-              <th key={header.id} colSpan={header.colSpan}>
-                {header.isPlaceholder ? null : header.renderHeader()}
-              </th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody>
-        {instance.getRowModel().rows.map(row => (
-          <tr key={row.id}>
-            {row.getVisibleCells().map(cell => (
-              <td key={cell.id}>{cell.renderCell()}</td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <div style={styles.wrapper}>
+      <table style={styles.table}>
+        <thead style={styles.head}>
+          {instance.getHeaderGroups().map(group => (
+            <tr key={group.id}>
+              {group.headers.map(header => (
+                <th key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : header.renderHeader()}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {instance.getRowModel().rows.map(row => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map(cell => (
+                <td key={cell.id} style={styles.cell}>
+                  {cell.renderCell()}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 });

--- a/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
+++ b/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
@@ -1,190 +1,59 @@
 import { TrackTableProps } from '@bassment/components/data/TrackTable/TrackTable.props';
-import { useTrackTableStyles } from '@bassment/components/data/TrackTable/TrackTable.style.web';
-import { ThemedText } from '@bassment/components/display/ThemedText';
-import { KeyedTag } from '@bassment/models/Tag';
+import React, { memo, useMemo, useState } from 'react';
+import {
+  createTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  useTableInstance,
+} from '@tanstack/react-table';
 import { AnnotatedTrack } from '@bassment/models/Track';
-import { useStyles } from '@bassment/styles';
-import { fromDrops } from '@bassment/utils/dropConversions.web';
-import React, { useCallback, useMemo, useState } from 'react';
-import DataGrid, {
-  Column,
-  Row,
-  RowRendererProps,
-  SortColumn,
-} from 'react-data-grid';
 
-function joinNames(xs: { name?: string }[]): string {
-  return xs.map(x => x.name ?? '').join(', ');
-}
+const table = createTable().setRowType<AnnotatedTrack>();
 
-function joinTags(tags: KeyedTag[]): string {
-  return tags.map(tag => `${tag.displayName}: ${tag.value}`).join(', ');
-}
+export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
+  const [selectedId, setSelectedId] = useState<number | undefined>(undefined);
 
-function compare(
-  x: AnnotatedTrack,
-  y: AnnotatedTrack,
-  columnKey: keyof AnnotatedTrack,
-) {
-  switch (columnKey) {
-    case 'id':
-      return (x[columnKey] ?? 0) - (y[columnKey] ?? 0);
-    case 'title':
-      return (x[columnKey] ?? '').localeCompare(y[columnKey] ?? '');
-    case 'artists':
-    case 'albums':
-      return joinNames(x[columnKey]).localeCompare(joinNames(y[columnKey]));
-    case 'tags':
-      return joinTags(x[columnKey]).localeCompare(joinTags(y[columnKey]));
-    default:
-      return 0;
-  }
-}
-
-export function TrackTable({ tracks, onPlay }: TrackTableProps) {
-  const [sortColumns, setSortColumns] = useState<readonly SortColumn[]>([]);
-  const [selectedRows, setSelectedRows] = useState<ReadonlySet<number>>(
-    () => new Set(),
-  );
-
-  const columns: Column<AnnotatedTrack>[] = useMemo(
+  const columns = useMemo(
     () => [
-      { key: 'id', name: 'ID', width: '4%' },
-      {
-        key: 'albums',
-        name: 'Album',
-        width: '15%',
-        formatter: ({ row }) => (
-          <ThemedText>{joinNames(row.albums)}</ThemedText>
-        ),
-      },
-      {
-        key: 'artists',
-        name: 'Artist',
-        width: '20%',
-        formatter: ({ row }) => (
-          <ThemedText>{joinNames(row.artists)}</ThemedText>
-        ),
-      },
-      { key: 'title', name: 'Title' },
-      {
-        key: 'tags',
-        name: 'Tags',
-        formatter: ({ row }) => <ThemedText>{joinTags(row.tags)}</ThemedText>,
-      },
+      table.createDataColumn('artists', {
+        header: () => 'Artists',
+      }),
+      table.createDataColumn('title', {
+        header: () => 'Title',
+      }),
     ],
     [],
   );
 
-  const rows: AnnotatedTrack[] = tracks;
-  const sortedRows = useMemo(() => {
-    return [...rows].sort((x, y) => {
-      for (const sort of sortColumns) {
-        const compResult = compare(
-          x,
-          y,
-          sort.columnKey as keyof AnnotatedTrack,
-        );
-        if (compResult !== 0) {
-          return sort.direction === 'ASC' ? compResult : -compResult;
-        }
-      }
-      return 0;
-    });
-  }, [rows, sortColumns]);
-
-  const globalStyles = useStyles();
-  const styles = useTrackTableStyles();
-
-  const onRowDoubleClick = useCallback(
-    (track: AnnotatedTrack) => {
-      if (onPlay) {
-        onPlay(track);
-      }
-    },
-    [onPlay],
-  );
-
-  const [lastClick, setLastClick] = useState<{
-    time: number;
-    trackId?: number;
-  }>({
-    time: 0,
+  const instance = useTableInstance(table, {
+    data: tracks,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
   });
 
-  const rowRenderer = useCallback(
-    (props: RowRendererProps<AnnotatedTrack>) => (
-      <Row
-        {...props}
-        draggable
-        onDragStart={e => {
-          const transfer = e.dataTransfer;
-
-          const img = document.createElement('img');
-          // TODO: Use a proper image
-          img.src = 'http://kryogenix.org/images/hackergotchi-simpler.png';
-          transfer.setDragImage(img, 0, 0);
-
-          fromDrops(
-            [
-              {
-                kind: 'tracks',
-                tracks: tracks.filter(t =>
-                  t.id ? selectedRows.has(t.id) : false,
-                ),
-              },
-            ],
-            transfer,
-          );
-        }}
-        onMouseDown={() => {
-          // We manually detect double-clicks since changing
-          // state during the onMouseDown will prevent the
-          // onDoubleClick from firing
-
-          const now = Date.now();
-          const trackId = props.row.id;
-
-          if (
-            (!lastClick.trackId || trackId === lastClick.trackId) &&
-            now - lastClick.time < 500 /* ms */
-          ) {
-            onRowDoubleClick(props.row);
-          }
-
-          setSelectedRows(new Set(trackId ? [trackId] : []));
-          setLastClick({ time: now, trackId });
-        }}
-      />
-    ),
-    [selectedRows, lastClick, tracks, onRowDoubleClick],
-  );
-
-  const getRowKey = useCallback((track: AnnotatedTrack) => track.id!, []);
-
   return (
-    <>
-      <DataGrid
-        rowKeyGetter={getRowKey}
-        style={styles.grid}
-        rowHeight={1.5 * globalStyles.text.fontSize}
-        columns={columns}
-        rows={sortedRows}
-        defaultColumnOptions={{
-          sortable: true,
-          resizable: true,
-        }}
-        selectedRows={selectedRows}
-        sortColumns={sortColumns}
-        onSelectedRowsChange={setSelectedRows}
-        onSortColumnsChange={setSortColumns}
-        onRowDoubleClick={onRowDoubleClick}
-        components={{
-          rowRenderer,
-        }}
-      />
-      {/* We patch the CSS at runtime since react-data-grid doesn't use react-native's styling. */}
-      <style>{styles.patched}</style>
-    </>
+    <table>
+      <thead>
+        {instance.getHeaderGroups().map(group => (
+          <tr key={group.id}>
+            {group.headers.map(header => (
+              <th key={header.id} colSpan={header.colSpan}>
+                {header.isPlaceholder ? null : header.renderHeader()}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {instance.getRowModel().rows.map(row => (
+          <tr key={row.id}>
+            {row.getVisibleCells().map(cell => (
+              <td key={cell.id}>{cell.renderCell()}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
-}
+});

--- a/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
+++ b/frontend/src/components/data/TrackTable/TrackTable.component.web.tsx
@@ -17,8 +17,17 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
 
   const columns = useMemo(
     () => [
+      table.createDataColumn('albums', {
+        header: () => 'Albums',
+        cell: ({ row: { original } }) =>
+          original?.albums.map(a => a.name).join(', '),
+        size: 30,
+      }),
       table.createDataColumn('artists', {
-        header: () => <div style={{ width: '50%' }}>Artists</div>,
+        header: () => 'Artists',
+        cell: ({ row: { original } }) =>
+          original?.artists.map(a => a.name).join(', '),
+        size: 30,
       }),
       table.createDataColumn('title', {
         header: () => 'Title',
@@ -41,7 +50,14 @@ export const TrackTable = memo(({ tracks, onPlay }: TrackTableProps) => {
           {instance.getHeaderGroups().map(group => (
             <tr key={group.id}>
               {group.headers.map(header => (
-                <th key={header.id} colSpan={header.colSpan}>
+                <th
+                  key={header.id}
+                  colSpan={header.colSpan}
+                  style={{
+                    ...styles.headCell,
+                    ...styles.cell,
+                    width: header.getSize(),
+                  }}>
                   {header.isPlaceholder ? null : header.renderHeader()}
                 </th>
               ))}

--- a/frontend/src/components/data/TrackTable/TrackTable.props.ts
+++ b/frontend/src/components/data/TrackTable/TrackTable.props.ts
@@ -2,5 +2,5 @@ import { AnnotatedTrack } from '@bassment/models/Track';
 
 export interface TrackTableProps {
   tracks: AnnotatedTrack[];
-  onPlay?: (track: AnnotatedTrack) => void;
+  onPlay?: (params: { track: AnnotatedTrack; base?: AnnotatedTrack[] }) => void;
 }

--- a/frontend/src/components/data/TrackTable/TrackTable.style.web.ts
+++ b/frontend/src/components/data/TrackTable/TrackTable.style.web.ts
@@ -2,29 +2,33 @@ import { useStyles } from '@bassment/styles';
 
 export function useTrackTableStyles() {
   const styles = useStyles();
-  return {
-    wrapper: {
-      height: '100%',
-      overflow: 'auto',
-      padding: 0,
-    },
-    table: {
-      width: '100%',
-      color: styles.text.color,
-      fontSize: styles.text.fontSize,
-      borderSpacing: '0',
-    },
-    head: {
-      position: 'sticky',
-      top: '0',
-      textAlign: 'left',
-      backgroundColor: styles.color.field,
-    },
-    headCell: {
-      padding: styles.layout.smallSpace,
-    },
-    cell: {
-      padding: `${styles.layout.tinySpace}px ${styles.layout.space}px`,
-    },
-  } as const;
+  return `
+    .tt-wrapper {
+      height: 100%;
+      overflow: auto;
+      padding: 0;
+    }
+
+    .tt-table {
+      width: 100%;
+      color: ${styles.text.color};
+      font-size: ${styles.text.fontSize}px;
+      border-spacing: 0;
+    }
+
+    .tt-head {
+      position: sticky;
+      top: 0;
+      text-align: left;
+      background-color: ${styles.color.field};
+    }
+
+    .tt-head-cell {
+      padding: ${styles.layout.smallSpace};
+    }
+
+    .tt-cell {
+      padding: ${styles.layout.tinySpace}px ${styles.layout.space}px;
+    }
+  `;
 }

--- a/frontend/src/components/data/TrackTable/TrackTable.style.web.ts
+++ b/frontend/src/components/data/TrackTable/TrackTable.style.web.ts
@@ -23,6 +23,10 @@ export function useTrackTableStyles() {
       background-color: ${styles.color.field};
     }
 
+    .tt-row:hover {
+      background-color: ${styles.color.hover};
+    }
+
     .tt-head-cell {
       padding: ${styles.layout.smallSpace};
     }

--- a/frontend/src/components/data/TrackTable/TrackTable.style.web.ts
+++ b/frontend/src/components/data/TrackTable/TrackTable.style.web.ts
@@ -3,28 +3,25 @@ import { useStyles } from '@bassment/styles';
 export function useTrackTableStyles() {
   const styles = useStyles();
   return {
-    grid: {
+    wrapper: {
       height: '100%',
+      overflow: 'auto',
+      padding: 0,
     },
-    patched: `
-      .rdg-row {
-        --rdg-row-hover-background-color: ${styles.color.hover};
-        --rdg-row-selected-background-color: ${styles.color.selection};
-        --row-selected-hover-background-color: ${styles.color.selection};
-        --rdg-selection-color: ${styles.color.selection};
-      }
-
-      .rdg-cell {
-        border: none;
-      }
-
-      .rdg-cell[aria-selected='true'] {
-        outline: none;
-      }
-
-      .selected-track {
-        background-color: ${styles.color.selection};
-      }
-    `,
-  };
+    table: {
+      width: '100%',
+      color: styles.text.color,
+      fontSize: styles.text.fontSize,
+      borderSpacing: '0px',
+    },
+    head: {
+      position: 'sticky',
+      top: '0',
+      padding: styles.layout.space,
+      backgroundColor: 'red',
+    },
+    cell: {
+      padding: `0 ${styles.layout.smallSpace}px`,
+    },
+  } as const;
 }

--- a/frontend/src/components/data/TrackTable/TrackTable.style.web.ts
+++ b/frontend/src/components/data/TrackTable/TrackTable.style.web.ts
@@ -12,16 +12,19 @@ export function useTrackTableStyles() {
       width: '100%',
       color: styles.text.color,
       fontSize: styles.text.fontSize,
-      borderSpacing: '0px',
+      borderSpacing: '0',
     },
     head: {
       position: 'sticky',
       top: '0',
-      padding: styles.layout.space,
-      backgroundColor: 'red',
+      textAlign: 'left',
+      backgroundColor: styles.color.field,
+    },
+    headCell: {
+      padding: styles.layout.smallSpace,
     },
     cell: {
-      padding: `0 ${styles.layout.smallSpace}px`,
+      padding: `${styles.layout.tinySpace}px ${styles.layout.space}px`,
     },
   } as const;
 }

--- a/frontend/src/components/data/TrackTable/TrackTable.style.web.ts
+++ b/frontend/src/components/data/TrackTable/TrackTable.style.web.ts
@@ -23,8 +23,12 @@ export function useTrackTableStyles() {
       background-color: ${styles.color.field};
     }
 
-    .tt-row:hover {
+    .tt-unselected:hover {
       background-color: ${styles.color.hover};
+    }
+
+    .tt-selected {
+      background-color: ${styles.color.selection};
     }
 
     .tt-head-cell {

--- a/frontend/src/components/data/TracksView/TracksView.component.tsx
+++ b/frontend/src/components/data/TracksView/TracksView.component.tsx
@@ -2,7 +2,7 @@ import { TrackTable } from '@bassment/components/data/TrackTable';
 import { AudioPlayerContext } from '@bassment/contexts/AudioPlayer';
 import { SearchContext } from '@bassment/contexts/Search';
 import { AnnotatedTrack } from '@bassment/models/Track';
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 
 interface TracksViewProps {
   tracks: AnnotatedTrack[];
@@ -31,6 +31,16 @@ export function TracksView({ tracks }: TracksViewProps) {
         )
       : tracks;
 
+  const onPlay = useCallback(
+    ({ track, base }: { track: AnnotatedTrack; base?: AnnotatedTrack[] }) => {
+      if (base) {
+        player.rebase(base);
+      }
+      player.play(track);
+    },
+    [player],
+  );
+
   // TODO: Other view on mobile
-  return <TrackTable tracks={filteredTracks} onPlay={player.play} />;
+  return <TrackTable tracks={filteredTracks} onPlay={onPlay} />;
 }

--- a/frontend/src/components/input/Droppable/Droppable.component.web.tsx
+++ b/frontend/src/components/input/Droppable/Droppable.component.web.tsx
@@ -38,6 +38,7 @@ export function Droppable({
   );
 
   return (
+    // TODO: onDragExit only seems to work in Firefox
     <div
       onDragEnter={onDragIn}
       onDragExit={onDragOut}

--- a/frontend/src/components/input/ForwardButton/ForwardButton.component.tsx
+++ b/frontend/src/components/input/ForwardButton/ForwardButton.component.tsx
@@ -11,8 +11,7 @@ export function ForwardButton({ onForward }: ForwardButtonProps) {
   const globalStyles = useStyles();
 
   return (
-    // TODO: Undisable
-    <ThemedButton hasBackground={false} onPress={onForward} disabled>
+    <ThemedButton hasBackground={false} onPress={onForward}>
       <ThemedIcon
         name={'play-forward-outline'}
         size={globalStyles.icon.largeSize}

--- a/frontend/src/components/input/PlaybackControls/PlaybackControls.component.tsx
+++ b/frontend/src/components/input/PlaybackControls/PlaybackControls.component.tsx
@@ -8,19 +8,23 @@ import { View } from 'react-native';
 interface PlaybackControlsProps {
   isPlaying: boolean;
   setPlaying: (playing: boolean) => void;
+  onBack: () => void;
+  onForward: () => void;
 }
 
 export function PlaybackControls({
   isPlaying,
   setPlaying,
+  onBack,
+  onForward,
 }: PlaybackControlsProps) {
   const styles = usePlaybackControlsStyles();
 
   return (
     <View style={styles.controls}>
-      <BackButton onBack={() => {}} />
+      <BackButton onBack={onBack} />
       <PlayButton isPlaying={isPlaying} setPlaying={setPlaying} />
-      <ForwardButton onForward={() => {}} />
+      <ForwardButton onForward={onForward} />
     </View>
   );
 }

--- a/frontend/src/components/navigation/QueueTreeItem/QueueTreeItem.component.tsx
+++ b/frontend/src/components/navigation/QueueTreeItem/QueueTreeItem.component.tsx
@@ -1,0 +1,45 @@
+import { ThemedIcon } from '@bassment/components/display/ThemedIcon';
+import { DropZone } from '@bassment/components/input/DropZone';
+import { DrawerTreeItem } from '@bassment/components/navigation/DrawerTreeItem';
+import { Drop, TracksDrop } from '@bassment/models/Drop';
+import { AnnotatedTrack } from '@bassment/models/Track';
+import React, { useCallback } from 'react';
+
+interface QueueTreeItemProps {
+  queueLength: number;
+  isFocused?: boolean;
+  onFocus?: () => void;
+  onEnqueue?: (tracks: AnnotatedTrack[]) => void;
+}
+
+export function QueueTreeItem({
+  queueLength,
+  isFocused,
+  onFocus,
+  onEnqueue,
+}: QueueTreeItemProps) {
+  const onDrop = useCallback(
+    (drops: Drop[]) => {
+      if (onEnqueue) {
+        const tracks = drops
+          .filter(drop => drop.kind === 'tracks')
+          .flatMap(drop => (drop as TracksDrop).tracks);
+        onEnqueue(tracks);
+      }
+    },
+    [onEnqueue],
+  );
+
+  return (
+    <DropZone onDrop={onDrop}>
+      <DrawerTreeItem
+        label={`Queue (${queueLength})`}
+        icon={({ size, color }) => (
+          <ThemedIcon name="trail-sign-outline" size={size} color={color} />
+        )}
+        isFocused={isFocused}
+        onPress={onFocus}
+      />
+    </DropZone>
+  );
+}

--- a/frontend/src/components/navigation/QueueTreeItem/index.ts
+++ b/frontend/src/components/navigation/QueueTreeItem/index.ts
@@ -1,0 +1,1 @@
+export * from './QueueTreeItem.component';

--- a/frontend/src/contexts/AudioPlayer/AudioPlayer.context.tsx
+++ b/frontend/src/contexts/AudioPlayer/AudioPlayer.context.tsx
@@ -70,9 +70,16 @@ export function AudioPlayerContextProvider(
 
   const enqueue = useCallback(
     (newTracks: AnnotatedTrack[]) => {
-      setQueue({ tracks: [...queue.tracks, ...newTracks] });
+      const nextTracks = [...queue.tracks, ...newTracks];
+      if (isPlaying) {
+        setQueue({ tracks: nextTracks });
+      } else if (nextTracks.length > 0) {
+        const nextTrack = nextTracks[0];
+        setQueue({ tracks: nextTracks.slice(1) });
+        play(nextTrack);
+      }
     },
-    [queue.tracks],
+    [queue.tracks, isPlaying, play],
   );
 
   const value: AudioPlayerContextValue = {

--- a/frontend/src/contexts/AudioPlayer/AudioPlayer.context.tsx
+++ b/frontend/src/contexts/AudioPlayer/AudioPlayer.context.tsx
@@ -26,6 +26,12 @@ export interface AudioPlayerContextValue {
   /** Plays the given track immediately. */
   play(track: AnnotatedTrack): void;
 
+  /** Plays the previous track. */
+  back(): void;
+
+  /** Skips to the next track. */
+  forward(): void;
+
   /** Appends the given tracks to the queue. */
   enqueue(tracks: AnnotatedTrack[]): void;
 
@@ -40,6 +46,8 @@ export const AudioPlayerContext = createContext<AudioPlayerContextValue>({
   isPlaying: false,
   setPlaying: () => {},
   play: () => {},
+  back: () => {},
+  forward: () => {},
   enqueue: () => {},
   rebase: () => {},
   seek: () => {},
@@ -93,17 +101,6 @@ export function AudioPlayerContextProvider(
     [queue],
   );
 
-  const value: AudioPlayerContextValue = {
-    nowPlaying: track ? { track, elapsedMs, totalMs } : undefined,
-    queue,
-    isPlaying,
-    setPlaying: setPlayingRequested,
-    play,
-    enqueue,
-    rebase,
-    seek: setSeekMs,
-  };
-
   const updateAudioUrl = useCallback(async () => {
     // TODO: More advanced logic for picking the file, e.g. by quality/file type?
     const audioFiles = track?.id ? await api.getTrackAudioFiles(track.id) : [];
@@ -146,6 +143,27 @@ export function AudioPlayerContextProvider(
       setPlayingRequested(false);
     }
   }, [queue]);
+
+  const back = useCallback(() => {
+    // TODO: Implement back
+  }, []);
+
+  const forward = useCallback(() => {
+    advanceQueue();
+  }, [advanceQueue]);
+
+  const value: AudioPlayerContextValue = {
+    nowPlaying: track ? { track, elapsedMs, totalMs } : undefined,
+    queue,
+    isPlaying,
+    setPlaying: setPlayingRequested,
+    play,
+    back,
+    forward,
+    enqueue,
+    rebase,
+    seek: setSeekMs,
+  };
 
   return (
     <AudioPlayerContext.Provider value={value}>

--- a/frontend/src/contexts/AudioPlayer/AudioPlayer.context.tsx
+++ b/frontend/src/contexts/AudioPlayer/AudioPlayer.context.tsx
@@ -101,23 +101,6 @@ export function AudioPlayerContextProvider(
     [queue],
   );
 
-  const updateAudioUrl = useCallback(async () => {
-    // TODO: More advanced logic for picking the file, e.g. by quality/file type?
-    const audioFiles = track?.id ? await api.getTrackAudioFiles(track.id) : [];
-    const audioFile = audioFiles.find(() => true);
-    const newAudioUrl = audioFile?.id
-      ? api.getFileDataUrl(audioFile.id)
-      : undefined;
-
-    setAudioUrl(newAudioUrl);
-    setPlayingRequested(newAudioUrl !== undefined);
-  }, [api, track]);
-
-  // Update the audio buffer whenever the current track changes
-  useEffect(() => {
-    updateAudioUrl();
-  }, [updateAudioUrl]);
-
   const updatePlaying = useCallback((newPlaying: boolean) => {
     setPlaying(newPlaying);
     setPlayingRequested(undefined);
@@ -143,6 +126,29 @@ export function AudioPlayerContextProvider(
       setPlayingRequested(false);
     }
   }, [queue]);
+
+  const updateAudioUrl = useCallback(async () => {
+    // TODO: More advanced logic for picking the file, e.g. by quality/file type?
+    const audioFiles = track?.id ? await api.getTrackAudioFiles(track.id) : [];
+    const audioFile = audioFiles.find(() => true);
+    const newAudioUrl = audioFile?.id
+      ? api.getFileDataUrl(audioFile.id)
+      : undefined;
+    const canPlay = newAudioUrl !== undefined;
+
+    if (canPlay) {
+      setAudioUrl(newAudioUrl);
+      setPlayingRequested(true);
+    } else {
+      // TODO: This seems to 'skip' over tracks, investigate why
+      // advanceQueue();
+    }
+  }, [api, track]);
+
+  // Update the audio buffer whenever the current track changes
+  useEffect(() => {
+    updateAudioUrl();
+  }, [updateAudioUrl]);
 
   const back = useCallback(() => {
     // TODO: Implement back

--- a/frontend/src/contexts/AudioPlayer/AudioPlayer.context.tsx
+++ b/frontend/src/contexts/AudioPlayer/AudioPlayer.context.tsx
@@ -26,6 +26,9 @@ export interface AudioPlayerContextValue {
   /** Plays the given track immediately. */
   play(track: AnnotatedTrack): void;
 
+  /** Appends the given tracks to the queue. */
+  enqueue(tracks: AnnotatedTrack[]): void;
+
   /** Seeks to the given offset in the current track. */
   seek(elapsedMs: number): void;
 }
@@ -34,6 +37,7 @@ export const AudioPlayerContext = createContext<AudioPlayerContextValue>({
   isPlaying: false,
   setPlaying: () => {},
   play: () => {},
+  enqueue: () => {},
   seek: () => {},
 });
 
@@ -64,12 +68,20 @@ export function AudioPlayerContextProvider(
     setPlayingRequested(true);
   }, []);
 
+  const enqueue = useCallback(
+    (newTracks: AnnotatedTrack[]) => {
+      setQueue({ tracks: [...queue.tracks, ...newTracks] });
+    },
+    [queue.tracks],
+  );
+
   const value: AudioPlayerContextValue = {
     nowPlaying: track ? { track, elapsedMs, totalMs } : undefined,
     queue,
     isPlaying,
     setPlaying: setPlayingRequested,
     play,
+    enqueue,
     seek: setSeekMs,
   };
 

--- a/frontend/src/models/TrackQueue.ts
+++ b/frontend/src/models/TrackQueue.ts
@@ -1,5 +1,8 @@
 import { AnnotatedTrack } from '@bassment/models/Track';
 
 export interface TrackQueue {
+  /** The queued tracks to be played next. */
   tracks: AnnotatedTrack[];
+  /** The tracks from the underlying base playlist. */
+  base: AnnotatedTrack[];
 }

--- a/frontend/src/panels/AppHeader/AppHeader.panel.tsx
+++ b/frontend/src/panels/AppHeader/AppHeader.panel.tsx
@@ -19,6 +19,8 @@ export function AppHeader(props: DrawerHeaderProps) {
           <PlaybackControls
             isPlaying={player.isPlaying}
             setPlaying={player.setPlaying}
+            onBack={player.back}
+            onForward={player.forward}
           />
         </View>
         <PlaybackView

--- a/frontend/src/panels/AppSidebar/AppSidebar.panel.tsx
+++ b/frontend/src/panels/AppSidebar/AppSidebar.panel.tsx
@@ -21,12 +21,15 @@ import { NavigationProp, useNavigation } from '@react-navigation/native';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { CategoryTreeNode } from '@bassment/models/Category';
 import { CategoryTreeItem } from '@bassment/components/navigation/CategoryTreeItem';
+import { QueueTreeItem } from '@bassment/components/navigation/QueueTreeItem';
+import { AudioPlayerContext } from '@bassment/contexts/AudioPlayer';
 
 export function AppSidebar(props: DrawerContentComponentProps) {
   const route = props.state.routes[props.state.index];
   const navigation: NavigationProp<SidebarNavigatorParams> = useNavigation();
   const styles = useAppSidebarStyles();
 
+  const player = useContext(AudioPlayerContext);
   const api = useContext(ApiContext);
   const { searchText, setSearchText } = useContext(SearchContext);
 
@@ -174,13 +177,10 @@ export function AppSidebar(props: DrawerContentComponentProps) {
         )}
       /> */}
       <Divider />
-      <DrawerTreeItem
-        label="Queue"
-        icon={({ size, color }) => (
-          <ThemedIcon name="trail-sign-outline" size={size} color={color} />
-        )}
+      <QueueTreeItem
+        queueLength={player.queue?.tracks.length ?? 0}
         isFocused={route.name === 'queue'}
-        onPress={() => {
+        onFocus={() => {
           navigation.navigate('queue', {});
         }}
       />

--- a/frontend/src/panels/AppSidebar/AppSidebar.panel.tsx
+++ b/frontend/src/panels/AppSidebar/AppSidebar.panel.tsx
@@ -183,6 +183,7 @@ export function AppSidebar(props: DrawerContentComponentProps) {
         onFocus={() => {
           navigation.navigate('queue', {});
         }}
+        onEnqueue={player.enqueue}
       />
       {/* TODO: Make Queue droppable, perhaps move it to a separate component? */}
       <Divider />


### PR DESCRIPTION
`react-table` is a headless table library, i.e. instead of letting the library handle this (as with `react-data-grid`) we render the entire table ourselves. This gives us more control and sidesteps the issues with click handling that we had with `react-data-grid`. However, we may need to manually implement e.g. virtualization using a library like `react-window` in the future.